### PR TITLE
Debreak Pyserial on Python 3

### DIFF
--- a/luaupload/esp8266.py
+++ b/luaupload/esp8266.py
@@ -32,7 +32,7 @@ class ESP8266:
 
 	def send(self, data):
 		if self.protocol == 'serial':
-			self.connection.write(data)
+			self.connection.write(data.encode())
 		elif self.protocol == 'telnet':
 			self.connection.send(data)
 		click.echo(data)


### PR DESCRIPTION
Fixes some weird unicode/encoding related bugs with Pyserial under Python 3.
